### PR TITLE
Add support for / \ " ' in tag match regex

### DIFF
--- a/lib/OfxParser/Parser.php
+++ b/lib/OfxParser/Parser.php
@@ -97,7 +97,7 @@ class Parser
 		// Matches: <SOMETHING>blah
 		// Does not match: <SOMETHING>
 		// Does not match: <SOMETHING>blah</SOMETHING>
-		if (preg_match("/<([A-Za-z0-9.]+)>([\w0-9\.\-\_\+\, :\[\]]+)$/", trim($line), $matches))
+		if (preg_match("/<([A-Za-z0-9.]+)>([\w0-9\.\-\_\+\, :\[\]\\\'\/\"]+)$/", trim($line), $matches))
 		{
 			return "<{$matches[1]}>{$matches[2]}</{$matches[1]}>";
 		}


### PR DESCRIPTION
Added some extra special chars to the tag match regex. Specifically \ / " ' characters. Bumped into examples of .ofx files containing these.
