### PR TITLE
Some banks use pipes in memos

### DIFF
--- a/lib/OfxParser/Parser.php
+++ b/lib/OfxParser/Parser.php
@@ -88,7 +88,7 @@ class Parser
 		// Matches: <SOMETHING>blah
 		// Does not match: <SOMETHING>
 		// Does not match: <SOMETHING>blah</SOMETHING>
-		if (preg_match("/<([A-Za-z0-9.]+)>([\wà-úÀ-Ú0-9\.\-\_\+\, ;:\[\]\'\&\/\\\*\(\)\+\{\}\!\£\$\?=@€£#%±§~`]+)$/", trim($line), $matches))
+		if (preg_match("/<([A-Za-z0-9.]+)>([\wà-úÀ-Ú0-9\.\-\_\+\, ;:\[\]\'\&\/\\\*\(\)\+\{\|\}\!\£\$\?=@€£#%±§~`]+)$/", trim($line), $matches))
 		{
 			return "<{$matches[1]}>{$matches[2]}</{$matches[1]}>";
 		}


### PR DESCRIPTION
The pipe character: `|` has been added to the regex in `closeUnclosedXmlTags()`.