### PR TITLE
Added support for CCACCTFROM tag variation

### DIFF
--- a/lib/OfxParser/Ofx.php
+++ b/lib/OfxParser/Ofx.php
@@ -184,12 +184,17 @@ class Ofx
      */
     private function buildCreditAccount(SimpleXMLElement $xml)
     {
+        $nodeName = 'CCACCTFROM';
+        if (!isset($xml->CCSTMTRS->$nodeName)) {
+            $nodeName = 'BANKACCTFROM';
+        }
+
         $creditAccount = new BankAccount();
         $creditAccount->transactionUid = $xml->TRNUID;
-        $creditAccount->agencyNumber = $xml->CCSTMTRS->BANKACCTFROM->BRANCHID;
-        $creditAccount->accountNumber = $xml->CCSTMTRS->BANKACCTFROM->ACCTID;
-        $creditAccount->routingNumber = $xml->CCSTMTRS->BANKACCTFROM->BANKID;
-        $creditAccount->accountType = $xml->CCSTMTRS->BANKACCTFROM->ACCTTYPE;
+        $creditAccount->agencyNumber = $xml->CCSTMTRS->$nodeName->BRANCHID;
+        $creditAccount->accountNumber = $xml->CCSTMTRS->$nodeName->ACCTID;
+        $creditAccount->routingNumber = $xml->CCSTMTRS->$nodeName->BANKID;
+        $creditAccount->accountType = $xml->CCSTMTRS->$nodeName->ACCTTYPE;
         $creditAccount->balance = $xml->CCSTMTRS->LEDGERBAL->BALAMT;
         $creditAccount->balanceDate = $this->createDateTimeFromStr($xml->CCSTMTRS->LEDGERBAL->DTASOF, true);
 

--- a/tests/OfxParser/ParserTest.php
+++ b/tests/OfxParser/ParserTest.php
@@ -9,6 +9,15 @@ use OfxParser\Parser;
  */
 class ParserTest extends \PHPUnit_Framework_TestCase
 {
+    public function testCreditCardStatementTransactionsAreLoaded()
+    {
+        $parser = new Parser();
+        $ofx = $parser->loadFromFile(__DIR__ . '/../fixtures/ofxdata-credit-card.ofx');
+
+        $account = reset($ofx->bankAccounts);
+        self::assertSame('1234567891234567', (string)$account->accountNumber);
+    }
+
     public function testXmlLoadStringThrowsExceptionWithInvalidXml()
     {
         $invalidXml = '<invalid xml>';
@@ -153,6 +162,7 @@ HERE
             [dirname(__DIR__).'/fixtures/ofxdata.ofx'],
             [dirname(__DIR__).'/fixtures/ofxdata-oneline.ofx'],
             [dirname(__DIR__).'/fixtures/ofxdata-cmfr.ofx'],
+            [dirname(__DIR__).'/fixtures/ofxdata-credit-card.ofx'],
         ];
     }
 

--- a/tests/fixtures/ofxdata-credit-card.ofx
+++ b/tests/fixtures/ofxdata-credit-card.ofx
@@ -1,0 +1,57 @@
+OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+SECURITY:NONE
+ENCODING:USASCII
+CHARSET:1252
+COMPRESSION:NONE
+OLDFILEUID:NONE
+NEWFILEUID:NONE
+<OFX>
+<SIGNONMSGSRSV1>
+    <SONRS>
+        <STATUS>
+            <CODE>0
+            <SEVERITY>INFO
+        </STATUS>
+        <DTSERVER>20160823000000
+        <LANGUAGE>ENG
+    </SONRS>
+</SIGNONMSGSRSV1>
+<CREDITCARDMSGSRSV1>
+    <CCSTMTTRNRS>
+        <TRNUID>20160823000000
+        <STATUS>
+            <CODE>0
+            <SEVERITY>INFO
+        </STATUS>
+        <CCSTMTRS>
+            <CURDEF>GBP
+            <CCACCTFROM>
+                <ACCTID>1234567891234567
+            </CCACCTFROM>
+            <BANKTRANLIST>
+                <DTSTART>20160823000000
+                <DTEND>20160823000000
+                <STMTTRN>
+                    <TRNTYPE>POS
+                    <DTPOSTED>20160823
+                    <DTUSER>20160823
+                    <TRNAMT>-100.00
+                    <FITID>ABCDEFGHIJ
+                    <REFNUM>VENDOR
+                    <NAME>VENDOR
+                </STMTTRN>
+            </BANKTRANLIST>
+            <LEDGERBAL>
+                <BALAMT>-500.00
+                <DTASOF>20160823000000
+            </LEDGERBAL>
+            <AVAILBAL>
+                <BALAMT>500.00
+                <DTASOF>20160823000000
+            </AVAILBAL>
+        </CCSTMTRS>
+    </CCSTMTTRNRS>
+</CREDITCARDMSGSRSV1>
+</OFX>


### PR DESCRIPTION
As reported in #16, this PR adds a variable node name and we now do a very basic test to find out what the node name should be. A bit ugly, but it works for now.