### PR TITLE
[FIX] Handling with double quotation marks

### DIFF
--- a/lib/OfxParser/Parser.php
+++ b/lib/OfxParser/Parser.php
@@ -98,7 +98,7 @@ class Parser
         // Does not match: <SOMETHING>
         // Does not match: <SOMETHING>blah</SOMETHING>
         if (preg_match(
-            "/<([A-Za-z0-9.]+)>([\wà-úÀ-Ú0-9\.\-\_\+\, ;:\[\]\'\&\/\\\*\(\)\+\{\|\}\!\£\$\?=@€£#%±§~`]+)$/",
+            "/<([A-Za-z0-9.]+)>([\wà-úÀ-Ú0-9\.\-\_\+\, ;:\[\]\'\"\&\/\\\*\(\)\+\{\|\}\!\£\$\?=@€£#%±§~`]+)$/",
             trim($line),
             $matches
         )) {


### PR DESCRIPTION
Handling with double quotation marks.
Example: <MEMO>IOF de "Amazon Web Services"